### PR TITLE
feat: avoid flash of loading component

### DIFF
--- a/src/components/non-ideal-state/non-ideal-state.css
+++ b/src/components/non-ideal-state/non-ideal-state.css
@@ -4,6 +4,12 @@
   flex-direction: column;
   justify-content: center;
   text-align: center;
+  transition: opacity 0.4s, visibility 0.4s;
+}
+
+.non-ideal-state.hide {
+  opacity: 0;
+  visibility: hidden;
 }
 
 .heading {

--- a/src/components/non-ideal-state/non-ideal-state.tsx
+++ b/src/components/non-ideal-state/non-ideal-state.tsx
@@ -1,14 +1,19 @@
 import "./non-ideal-state.css";
 
+import classNames from "classnames";
+
+import { useDelayShow } from "../../hooks";
+
 export type NonIdealStateProps = {
   description?: string;
   title: string;
 };
 
 export const NonIdealState = ({ description, title }: NonIdealStateProps) => {
-  // TODO: Add icon
+  const show = useDelayShow(1000);
+
   return (
-    <div className="non-ideal-state">
+    <div className={classNames("non-ideal-state", { hide: !show })}>
       <div className="non-ideal-state-visual"></div>
       <h4 className="heading">{title}</h4>
       {description && <div>{description}</div>}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./useDelayShow";
+export * from "./useWhyDidYouUpdate";

--- a/src/hooks/useDelayShow.ts
+++ b/src/hooks/useDelayShow.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+export const useDelayShow = (delay: number = 300) => {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setShow(true), delay);
+
+    return () => clearTimeout(timeout);
+  }, [delay]);
+
+  return show;
+};


### PR DESCRIPTION
It's quite jarring to see a 'Loading' text pop up and quickly be replaced by the chart. This PR delays displaying the loading component to give the chart a chance to load.