### PR TITLE
feat: make simple mode more simple

### DIFF
--- a/src/components/chart/chart.stories.tsx
+++ b/src/components/chart/chart.stories.tsx
@@ -16,12 +16,15 @@ const Template: Story<ChartProps> = (args) => (
   </div>
 );
 
-export const Simple = Template.bind({});
-Simple.args = { dataSource: new JsonDataSource("", 5), interval: Interval.I5M };
+export const Default = Template.bind({});
+Default.args = {
+  dataSource: new JsonDataSource("", 5),
+  interval: Interval.I5M,
+};
 
 export const Study = Template.bind({});
 Study.args = {
-  ...Simple.args,
+  ...Default.args,
   options: {
     chartType: "area",
     studies: ["macd"],
@@ -30,9 +33,15 @@ Study.args = {
 
 export const Positions = Template.bind({});
 Positions.args = {
-  ...Simple.args,
-  options: { ...Simple.args.options, chartType: "area" },
+  ...Default.args,
+  options: { chartType: "area" },
 };
 
 export const NoData = Template.bind({});
 NoData.args = { dataSource: new EmptyDataSource(), interval: Interval.I5M };
+
+export const SimpleMode = Template.bind({});
+SimpleMode.args = {
+  ...Default.args,
+  options: { studies: ["volume"], simple: true },
+};

--- a/src/components/chart/chart.tsx
+++ b/src/components/chart/chart.tsx
@@ -199,7 +199,7 @@ export const Chart = forwardRef(
     // React to streaming annotations changes
     useEffect(() => {
       function subscribe() {
-        if (dataSource.subscribeAnnotations) {
+        if (dataSource.subscribeAnnotations && !simple) {
           dataSource.subscribeAnnotations((annotations) => {
             setAnnotations(annotations);
           });
@@ -217,7 +217,7 @@ export const Chart = forwardRef(
           setAnnotations([]);
         };
       }
-    }, [dataSource, loading]);
+    }, [dataSource, loading, simple]);
 
     const handleViewportChanged = useCallback(
       (viewport: Viewport) => {

--- a/src/components/pane-view/pane-view.tsx
+++ b/src/components/pane-view/pane-view.tsx
@@ -50,7 +50,7 @@ export const PaneView = forwardRef<HTMLDivElement, PaneViewProps>(
             width: simple ? 0 : `${Y_AXIS_WIDTH}px`,
           }}
         />
-        {pane.id !== "main" && (
+        {pane.id !== "main" && !simple && (
           <div
             className="pane__close-button-wrapper"
             style={{

--- a/src/components/pane-view/pane-view.tsx
+++ b/src/components/pane-view/pane-view.tsx
@@ -37,7 +37,7 @@ export const PaneView = forwardRef<HTMLDivElement, PaneViewProps>(
         onMouseOut={() => setShowPaneControls(null)}
       >
         <d3fc-canvas class="plot-area" use-device-pixel-ratio />
-        <d3fc-svg class="plot-area-interaction" />
+        {!simple && <d3fc-svg class="plot-area-interaction" />}
         <div className="plot-area-annotations" />
         <d3fc-canvas
           class="y-axis"

--- a/src/components/plot-container/plot-container.tsx
+++ b/src/components/plot-container/plot-container.tsx
@@ -268,6 +268,7 @@ export const PlotContainer = forwardRef<
             chartRef.current?.requestRedraw();
             onProportionChanged(proportion);
           }}
+          simple={simple}
         />
         <XAxisView ref={xAxisRef} simple={simple} />
       </d3fc-group>

--- a/src/components/split-view/split-view.tsx
+++ b/src/components/split-view/split-view.tsx
@@ -18,6 +18,7 @@ export type SplitViewProps = {
   showStudy: boolean;
   initialProportion: number;
   onResize?: (proportion: number) => void;
+  simple?: boolean;
 };
 
 const styles = getComputedStyle(document.documentElement);
@@ -32,6 +33,7 @@ export const SplitView = ({
   showStudy = false,
   initialProportion = 2 / 3,
   onResize,
+  simple = false,
 }: SplitViewProps) => {
   const splitViewRef = useRef<HTMLDivElement>(null!);
   const sashRef = useRef<HTMLDivElement>(null!);
@@ -48,7 +50,9 @@ export const SplitView = ({
 
   const layout = useCallback(() => {
     if (showStudy) {
-      sashRef.current.style.top = `${size.current - sashSize / 2}px`;
+      if (sashRef.current) {
+        sashRef.current.style.top = `${size.current - sashSize / 2}px`;
+      }
       mainRef.current.style.top = `${0}px`;
       mainRef.current.style.height = `${size.current}px`;
       studyRef.current.style.top = `${size.current}px`;
@@ -152,13 +156,13 @@ export const SplitView = ({
       className="pennant-split-view vertical separator-border"
     >
       <div className="sash-container">
-        {showStudy && (
+        {showStudy && !simple && (
           <div
             ref={sashRef}
             className="pennant-sash horizontal"
-            onMouseDown={handleMouseDown}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
+            onMouseDown={simple ? undefined : handleMouseDown}
+            onMouseEnter={simple ? undefined : handleMouseEnter}
+            onMouseLeave={simple ? undefined : handleMouseLeave}
           />
         )}
       </div>

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -52,6 +52,11 @@ import { XAxisInteraction } from "./x-axis-interaction";
 import { YAxis } from "./y-axis";
 import { YAxisInteraction } from "./y-axis-interaction";
 
+// Padding between center of right-most candle and y-axis or right hand edge
+function getCandlePadding(isSimple: boolean, intervalWidth: number) {
+  return (isSimple ? 0 : Y_AXIS_WIDTH) + (isSimple ? 0.5 : 3) * intervalWidth;
+}
+
 export type Panes<T> = { [id: string]: T };
 
 export type ChartPane = {
@@ -544,7 +549,7 @@ export class Core {
 
     const latestDate = this.dates[this.dates.length - 1];
     const previousLatestDate = xr.invert(
-      xr.range()[1] - (this.isSimple ? 0 : Y_AXIS_WIDTH) - intervalWidth * 3
+      xr.range()[1] - getCandlePadding(this.isSimple, intervalWidth)
     );
 
     if (compareAsc(latestDate, previousLatestDate) === 1) {
@@ -566,8 +571,7 @@ export class Core {
     const ratio =
       width /
       (this.xScale.range()[1] -
-        (this.isSimple ? 0 : Y_AXIS_WIDTH) -
-        intervalWidth * 3 -
+        getCandlePadding(this.isSimple, intervalWidth) -
         this.xScale.range()[0]);
 
     const date0 = new Date(
@@ -575,8 +579,7 @@ export class Core {
         (Math.abs(
           this.xScale.range()[1] -
             this.xScale.range()[0] -
-            (this.isSimple ? 0 : Y_AXIS_WIDTH) -
-            (this.isSimple ? 0 : 3 * intervalWidth)
+            getCandlePadding(this.isSimple, intervalWidth)
         ) /
           intervalWidth) *
           1000 *
@@ -888,10 +891,12 @@ export class Core {
 
   private zoom(delta: number) {
     const xr = this.xTransform().rescaleX(this.xScale);
+    const intervalWidth = DEFAULT_INTERVAL_WIDTH;
 
     this.xElement.call(this.xZoom.scaleBy, 2 ** delta, [
       this.isPinned
-        ? this.xScale.range()[1] - (this.isSimple ? 0 : Y_AXIS_WIDTH)
+        ? this.xScale.range()[1] -
+          getCandlePadding(this.isSimple, intervalWidth)
         : (this.xScale.range()[0] + this.xScale.range()[1]) / 2,
       0,
     ]);

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -544,7 +544,11 @@ export class Core {
   }
 
   pinXAxis(): void {
-    const intervalWidth = DEFAULT_INTERVAL_WIDTH;
+    const width = this.xScale.range()[1] - this.xScale.range()[0];
+
+    const intervalWidth =
+      width / this.initialNumCandles ?? DEFAULT_INTERVAL_WIDTH;
+
     const xr = this.xTransform().rescaleX(this.xScale);
 
     const latestDate = this.dates[this.dates.length - 1];
@@ -553,8 +557,7 @@ export class Core {
     );
 
     if (compareAsc(latestDate, previousLatestDate) === 1) {
-      const difference =
-        this.xScale(latestDate) - this.xScale(previousLatestDate);
+      const difference = xr(latestDate) - xr(previousLatestDate);
 
       this.xElement.call(this.xZoom.translateBy, -difference, 0);
     }
@@ -597,16 +600,6 @@ export class Core {
 
     this.xScale.domain(domain);
     this.xElement.call(this.xZoom.transform, zoomIdentity);
-    /* 
-    for (const plotArea of Object.values(this.plotAreas)) {
-      plotArea.crosshair([null, null]);
-    }
-
-    this.xAxis.crosshair(null);
-
-    for (const axis of Object.values(this.yAxes)) {
-      axis.crosshair(null);
-    } */
   }
 
   resetYAxis(id: string) {


### PR DESCRIPTION
- Renames `Simple` story to `Default` and adds a new `SimpleMode` story to show a chart rendered in simple mode.
- Doesnt render the interaction component in simple mode to prevent zoom and pan.
- Doesnt render the resize sash in simple mode, and checks for sash ref existence before setting inline style
- Doesnt subscribe to annotations in simple mode

TODO:
- [x] Remove padding to the right of the most recent candle