### PR TITLE
feat: match overlay indicator info colors with chart colors

### DIFF
--- a/src/components/chart/helpers/helpers-color.ts
+++ b/src/components/chart/helpers/helpers-color.ts
@@ -95,3 +95,7 @@ export function getColors(element: HTMLElement | null): Colors {
       COLORS.VEGA_RED,
   };
 }
+
+export function getAccentColor(n: number) {
+  return `accent${1 + (n % 6)}` as keyof Colors;
+}

--- a/src/components/indicator-info/indicator-info.stories.tsx
+++ b/src/components/indicator-info/indicator-info.stories.tsx
@@ -8,7 +8,13 @@ export default {
 } as Meta;
 
 const Template: Story<IndicatorInfoProps> = (args) => (
-  <div style={{ backgroundColor: "black", padding: "24px 24px" }}>
+  <div
+    style={{
+      backgroundColor: "var(--pennant-background-surface-color)",
+      color: "var(--pennant-font-color-base)",
+      padding: "24px 24px",
+    }}
+  >
     <IndicatorInfo {...args} />
   </div>
 );
@@ -39,4 +45,19 @@ export const RelativeStrengthIndicator = Template.bind({});
 RelativeStrengthIndicator.args = {
   title: "RSI",
   info: [{ id: "index", label: "", value: "100" }],
+};
+
+export const Closable = Template.bind({});
+
+Closable.args = {
+  title: "RSI",
+  info: [{ id: "index", label: "", value: "100" }],
+  closeable: true,
+};
+
+export const Colors = Template.bind({});
+
+Colors.args = {
+  title: "RSI",
+  info: [{ id: "index", label: "", value: "100", color: "#ffff00" }],
 };

--- a/src/components/indicator-info/indicator-info.tsx
+++ b/src/components/indicator-info/indicator-info.tsx
@@ -12,6 +12,7 @@ export type IndicatorInfoProps = {
     label?: string;
     value: string;
     intent?: "success" | "danger";
+    color?: string;
   }[];
   closeable?: boolean;
   onClose?: () => void;
@@ -39,6 +40,9 @@ export const IndicatorInfo = ({
                 danger: d.intent === "danger",
               }
             )}
+            {...(d.color && {
+              style: { color: d.color },
+            })}
           >
             {d.value}
           </span>

--- a/src/components/pane-view/pane-view.tsx
+++ b/src/components/pane-view/pane-view.tsx
@@ -5,12 +5,14 @@ import React, { forwardRef, useState } from "react";
 import { Y_AXIS_WIDTH } from "../../constants";
 import { formatter } from "../../helpers";
 import { Bounds, Pane } from "../../types";
+import { Colors, getAccentColor } from "../chart/helpers";
 import { CloseButton } from "../close-button";
 import { IndicatorInfo } from "../indicator-info";
 import { getIntent, getStudyInfoFieldValue, studyInfoFields } from "./helpers";
 
 export type PaneViewProps = {
   bounds: Bounds | null;
+  colors: Colors;
   dataIndex: number | null;
   decimalPlaces: number;
   overlays: string[];
@@ -24,6 +26,7 @@ export const PaneView = forwardRef<HTMLDivElement, PaneViewProps>(
   (
     {
       bounds,
+      colors,
       dataIndex,
       decimalPlaces,
       overlays,
@@ -37,6 +40,8 @@ export const PaneView = forwardRef<HTMLDivElement, PaneViewProps>(
     const [showPaneControls, setShowPaneControls] = useState<string | null>(
       null
     );
+
+    let colorCount = 0;
 
     return (
       <div
@@ -121,6 +126,7 @@ export const PaneView = forwardRef<HTMLDivElement, PaneViewProps>(
                     value: field.format
                       ? field.format(value, decimalPlaces)
                       : formatter(value, decimalPlaces),
+                    color: colors[getAccentColor(colorCount++)],
                   };
                 })}
                 closeable

--- a/src/components/plot-container/plot-container.tsx
+++ b/src/components/plot-container/plot-container.tsx
@@ -254,6 +254,7 @@ export const PlotContainer = forwardRef<
               <PaneView
                 ref={refs[pane.id]}
                 bounds={bounds}
+                colors={colors}
                 dataIndex={dataIndex}
                 decimalPlaces={decimalPlaces}
                 overlays={overlays}

--- a/src/helpers/helpers-spec.test.ts
+++ b/src/helpers/helpers-spec.test.ts
@@ -150,13 +150,13 @@ describe("constructTopLevelSpec", () => {
               encoding: {
                 y: { field: "bollingerLower", type: "quantitative" },
               },
-              mark: { color: "#ff261a", type: "line" },
+              mark: { color: "#d9822b", type: "line" },
             },
             {
               encoding: {
                 y: { field: "bollingerUpper", type: "quantitative" },
               },
-              mark: { color: "#ff261a", type: "line" },
+              mark: { color: "#daff0d", type: "line" },
             },
           ],
         },

--- a/src/helpers/helpers-spec.ts
+++ b/src/helpers/helpers-spec.ts
@@ -1,4 +1,4 @@
-import { Colors } from "../components/chart/helpers";
+import { Colors, getAccentColor } from "../components/chart/helpers";
 import { Candle, ChartType, Overlay, Study } from "../types";
 import { BaseSpec, TopLevelSpec } from "../vega-lite/spec";
 import { Transform } from "../vega-lite/transform";
@@ -247,112 +247,6 @@ function constructStudyLayerSpec(study: Study, colors: Colors): BaseSpec[] {
   }
 }
 
-function constructOverlayLayerSpec(
-  overlay: Overlay,
-  colors: Colors
-): BaseSpec[] {
-  switch (overlay) {
-    case "bollinger":
-      return [
-        {
-          encoding: {
-            y: { field: "bollingerLower", type: "quantitative" },
-          },
-          mark: {
-            type: "line",
-            color: colors.accent3,
-          },
-        },
-        {
-          encoding: {
-            y: { field: "bollingerUpper", type: "quantitative" },
-          },
-          mark: {
-            type: "line",
-            color: colors.accent3,
-          },
-        },
-      ];
-    case "envelope":
-      return [
-        {
-          encoding: {
-            y: { field: "envelopeLower", type: "quantitative" },
-          },
-          mark: {
-            type: "line",
-            color: colors.accent1,
-          },
-        },
-        {
-          encoding: {
-            y: { field: "envelopeUpper", type: "quantitative" },
-          },
-          mark: {
-            type: "line",
-            color: colors.accent1,
-          },
-        },
-      ];
-    case "exponentialMovingAverage":
-      return [
-        {
-          encoding: {
-            y: { field: "exponentialMovingAverage", type: "quantitative" },
-          },
-          mark: {
-            type: "line",
-            color: colors.accent2,
-          },
-        },
-      ];
-    case "movingAverage":
-      return [
-        {
-          encoding: {
-            y: { field: "movingAverage", type: "quantitative" },
-          },
-          mark: {
-            type: "line",
-            color: colors.accent1,
-          },
-        },
-      ];
-    case "priceMonitoringBounds":
-      return [
-        {
-          encoding: {
-            y: { field: "minValidPrice", type: "quantitative" },
-          },
-          mark: {
-            type: "line",
-            color: colors.vegaOrange,
-          },
-        },
-        {
-          encoding: {
-            y: { field: "maxValidPrice", type: "quantitative" },
-          },
-          mark: {
-            type: "line",
-            color: colors.vegaGreen,
-          },
-        },
-        {
-          encoding: {
-            y: { field: "referencePrice", type: "quantitative" },
-          },
-          mark: {
-            type: "line",
-            color: colors.accent1,
-          },
-        },
-      ];
-    default:
-      return [];
-  }
-}
-
 function constructOverlayTransform(overlay: Overlay): Transform[] {
   switch (overlay) {
     case "bollinger":
@@ -442,6 +336,111 @@ export function constructTopLevelSpec(
   const vconcat: BaseSpec[] = [];
   const transform: Transform[] = [];
 
+  let colorIndex = 0;
+
+  function constructOverlayLayerSpec(overlay: Overlay): BaseSpec[] {
+    switch (overlay) {
+      case "bollinger":
+        return [
+          {
+            encoding: {
+              y: { field: "bollingerLower", type: "quantitative" },
+            },
+            mark: {
+              type: "line",
+              color: colors[getAccentColor(colorIndex++)],
+            },
+          },
+          {
+            encoding: {
+              y: { field: "bollingerUpper", type: "quantitative" },
+            },
+            mark: {
+              type: "line",
+              color: colors[getAccentColor(colorIndex++)],
+            },
+          },
+        ];
+      case "envelope":
+        return [
+          {
+            encoding: {
+              y: { field: "envelopeLower", type: "quantitative" },
+            },
+            mark: {
+              type: "line",
+              color: colors[getAccentColor(colorIndex++)],
+            },
+          },
+          {
+            encoding: {
+              y: { field: "envelopeUpper", type: "quantitative" },
+            },
+            mark: {
+              type: "line",
+              color: colors[getAccentColor(colorIndex++)],
+            },
+          },
+        ];
+      case "exponentialMovingAverage":
+        return [
+          {
+            encoding: {
+              y: { field: "exponentialMovingAverage", type: "quantitative" },
+            },
+            mark: {
+              type: "line",
+              color: colors[getAccentColor(colorIndex++)],
+            },
+          },
+        ];
+      case "movingAverage":
+        return [
+          {
+            encoding: {
+              y: { field: "movingAverage", type: "quantitative" },
+            },
+            mark: {
+              type: "line",
+              color: colors[getAccentColor(colorIndex++)],
+            },
+          },
+        ];
+      case "priceMonitoringBounds":
+        return [
+          {
+            encoding: {
+              y: { field: "minValidPrice", type: "quantitative" },
+            },
+            mark: {
+              type: "line",
+              color: colors[getAccentColor(colorIndex++)],
+            },
+          },
+          {
+            encoding: {
+              y: { field: "maxValidPrice", type: "quantitative" },
+            },
+            mark: {
+              type: "line",
+              color: colors[getAccentColor(colorIndex++)],
+            },
+          },
+          {
+            encoding: {
+              y: { field: "referencePrice", type: "quantitative" },
+            },
+            mark: {
+              type: "line",
+              color: colors[getAccentColor(colorIndex++)],
+            },
+          },
+        ];
+      default:
+        return [];
+    }
+  }
+
   const mainSpecification: BaseSpec = {
     name: "main",
     layer: constructMainLayerSpec(chartType, colors),
@@ -450,9 +449,7 @@ export function constructTopLevelSpec(
   if (overlays && overlays.length) {
     for (const overlay of overlays) {
       transform.push(...constructOverlayTransform(overlay));
-      mainSpecification.layer?.push(
-        ...constructOverlayLayerSpec(overlay, colors)
-      );
+      mainSpecification.layer?.push(...constructOverlayLayerSpec(overlay));
     }
   }
 


### PR DESCRIPTION
Closes #470.

Slightly hacky version to get something working.

The colorus are not stable. Ideally once an overlay has been added the colours associated with it should not change. Instead this PR has the colours change as the order of the overlays changes.

<img width="577" alt="Screenshot 2022-06-28 at 18 04 42" src="https://user-images.githubusercontent.com/981531/176241457-540aa945-a0e4-4607-a79b-37a465fa2d53.png">
