### PR TITLE
feat: add volumeFormat prop to depth-chart

### DIFF
--- a/src/components/depth-chart/chart.ts
+++ b/src/components/depth-chart/chart.ts
@@ -26,11 +26,6 @@ function getMidPrice(
   return mean([buyPrice, sellPrice]) as number;
 }
 
-export const volumeFormatter = new Intl.NumberFormat("en-gb", {
-  maximumFractionDigits: 0,
-  minimumFractionDigits: 0,
-});
-
 // Ratio of price percentage change to volume percentage change used to detect outliers
 const PRICE_VOLUME_RATIO_THRESHOLD = 100;
 
@@ -60,6 +55,7 @@ export class Chart extends EventEmitter {
   private _midPrice: number = 0;
 
   private priceFormat: (price: number) => string;
+  private volumeFormat: (volume: number) => string;
 
   private _colors: Colors;
 
@@ -70,11 +66,13 @@ export class Chart extends EventEmitter {
     width: number;
     height: number;
     priceFormat: (price: number) => string;
+    volumeFormat: (volume: number) => string;
     colors: Colors;
   }) {
     super();
 
     this.priceFormat = options.priceFormat;
+    this.volumeFormat = options.volumeFormat;
     this._colors = options.colors;
 
     this.chart = new Contents({
@@ -331,9 +329,7 @@ export class Chart extends EventEmitter {
       (priceLevel) => priceLevel[1]
     );
 
-    this.volumeLabels = this.volumes.map((volume) =>
-      volumeFormatter.format(volume)
-    );
+    this.volumeLabels = this.volumes.map((volume) => this.volumeFormat(volume));
 
     this.update();
     this.render();

--- a/src/components/depth-chart/depth-chart.stories.tsx
+++ b/src/components/depth-chart/depth-chart.stories.tsx
@@ -8,7 +8,7 @@ import {
   DepthChart,
   DepthChartHandle,
   DepthChartProps,
-  priceFormatter,
+  numberFormatter,
   PriceLevel,
 } from "./depth-chart";
 
@@ -389,56 +389,72 @@ const Template: Story<DepthChartProps> = (args) => {
 export const AAPL = Template.bind({});
 AAPL.args = {
   data: AAPL_data,
-  priceFormat: (price: number) => priceFormatter(5).format(price),
+  priceFormat: (price: number) => numberFormatter(5).format(price),
 };
 
 export const ETHBTC = Template.bind({});
 ETHBTC.args = {
   data: ETHBTC_data,
-  priceFormat: (price: number) => priceFormatter(5).format(price),
+  priceFormat: (price: number) => numberFormatter(5).format(price),
   indicativePrice: 0.065,
 };
 
 export const UNIDAI = Template.bind({});
 UNIDAI.args = {
   data: UNIDAI_data,
-  priceFormat: (price: number) => priceFormatter(5).format(price),
+  priceFormat: (price: number) => numberFormatter(5).format(price),
   indicativePrice: 30,
 };
 
 export const BTCUSD = Template.bind({});
 BTCUSD.args = {
   data: BTCUSD_data,
-  priceFormat: (price: number) => priceFormatter(5).format(price),
+  priceFormat: (price: number) => numberFormatter(5).format(price),
   midPrice: 44256,
 };
 
 export const SinglePriceLevel = Template.bind({});
 SinglePriceLevel.args = {
   data: { buy: AAPL_data.buy.slice(0, 1), sell: [] },
-  priceFormat: (price: number) => priceFormatter(5).format(price),
+  priceFormat: (price: number) => numberFormatter(5).format(price),
 };
 
 export const LeftSided = Template.bind({});
 LeftSided.args = {
   data: { buy: AAPL_data.buy, sell: [] },
-  priceFormat: (price: number) => priceFormatter(5).format(price),
+  priceFormat: (price: number) => numberFormatter(5).format(price),
 };
 
 export const RightSided = Template.bind({});
 RightSided.args = {
   data: { buy: [], sell: AAPL_data.sell },
-  priceFormat: (price: number) => priceFormatter(5).format(price),
+  priceFormat: (price: number) => numberFormatter(5).format(price),
 };
 
 export const NoData = Template.bind({});
 NoData.args = {
   data: { buy: [], sell: [] },
-  priceFormat: (price: number) => priceFormatter(5).format(price),
+  priceFormat: (price: number) => numberFormatter(5).format(price),
 };
 
 export const InitialZoom = Template.bind({});
 InitialZoom.args = {
   data: { buy: zoomedOutData.buy, sell: zoomedOutData.sell },
-  priceFormat: (price: number) => priceFormatter(5).format(price),
+  priceFormat: (price: number) => numberFormatter(5).format(price),
+};
+
+export const FractionalVolume = Template.bind({});
+FractionalVolume.args = {
+  data: {
+    buy: AAPL_data.buy.map((priceLevel) => ({
+      price: priceLevel.price,
+      volume: priceLevel.volume / 100,
+    })),
+    sell: AAPL_data.sell.map((priceLevel) => ({
+      price: priceLevel.price,
+      volume: priceLevel.volume / 100,
+    })),
+  },
+  priceFormat: (price: number) => numberFormatter(5).format(price),
+  volumeFormat: (volume: number) => numberFormatter(2).format(volume),
 };

--- a/src/components/depth-chart/depth-chart.tsx
+++ b/src/components/depth-chart/depth-chart.tsx
@@ -15,17 +15,21 @@ import styles from "./depth-chart.module.css";
 import { getColors } from "./helpers";
 
 /**
- * Creates a price formatter
+ * Creates a number formatter
  * @param decimalPlaces Number of decimal places to display
  */
-export const priceFormatter = (decimalPlaces: number): Intl.NumberFormat =>
+export const numberFormatter = (decimalPlaces: number): Intl.NumberFormat =>
   new Intl.NumberFormat("en-gb", {
     maximumFractionDigits: decimalPlaces,
     minimumFractionDigits: decimalPlaces,
   });
 
 function defaultPriceFormat(price: number) {
-  return priceFormatter(2).format(price);
+  return numberFormatter(2).format(price);
+}
+
+function defaultVolumeFormat(volume: number) {
+  return numberFormatter(0).format(volume);
 }
 
 /**
@@ -45,8 +49,10 @@ export type PriceLevel = {
 
 export type DepthChartProps = {
   data: { buy: PriceLevel[]; sell: PriceLevel[] };
-  /** Used to format tick labels on price axis */
+  /** Used to format values on price axis */
   priceFormat?: (price: number) => string;
+  /** Used to format values volume axis */
+  volumeFormat?: (price: number) => string;
   /** Indicative price if the auction ended now, 0 if not in auction mode */
   indicativePrice?: number;
   /** Arithmetic average of the best bid price and best offer price. */
@@ -72,6 +78,7 @@ export const DepthChart = forwardRef(
     {
       data,
       priceFormat = defaultPriceFormat,
+      volumeFormat = defaultVolumeFormat,
       indicativePrice = 0,
       midPrice = 0,
       theme = "dark",
@@ -104,6 +111,7 @@ export const DepthChart = forwardRef(
         width: 300,
         height: 300,
         priceFormat,
+        volumeFormat,
         colors,
       });
 

--- a/website/docs/depth-chart.md
+++ b/website/docs/depth-chart.md
@@ -10,6 +10,7 @@ title: DepthChart
 | Name              | Type       | Default | Description                                                          |
 | ----------------- | ---------- | ------- | -------------------------------------------------------------------- |
 | `data`            | `object`   |         |                                                                      |
-| `priceFormat`     | `function` |         | Used to format tick labels on price axis.                            |
+| `priceFormat`     | `function` |         | Used to format values on price axis.                                 |
+| `volumeFormat`    | `function` |         | Used to format values on volume axis.                                |
 | `indicativePrice` | `number`   |         | Indicative price if the auction ended now, 0 if not in auction mode. |
 | `midPrice`        | `number`   |         | Arithmetic average of the best bid price and best offer price.       |


### PR DESCRIPTION
Closes #541.

Adds a `volumeFormat` prop to the depth chart. This is a function which takes a number and returns a string.

In the screenshot below the volume is formatted to 2 decimals places.

<img width="297" alt="Screenshot 2022-08-10 at 11 57 51" src="https://user-images.githubusercontent.com/981531/183885233-9518966a-06c4-4db2-996b-2edbc68ecbd8.png">

<img width="849" alt="Screenshot 2022-08-10 at 12 02 53" src="https://user-images.githubusercontent.com/981531/183885919-7c61d58a-cd12-4b6c-845e-463f19eeb33c.png">


