### PR TITLE
chore: make notEnoughDataText more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# IDEs
+/.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pennant",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A React component library for visualising historical and streaming financial market data",
   "main": "./dist/legacy.js",
   "types": "./dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pennant",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "description": "A React component library for visualising historical and streaming financial market data",
   "main": "./dist/legacy.js",
   "types": "./dist/types/index.d.ts",

--- a/src/components/chart/chart.stories.tsx
+++ b/src/components/chart/chart.stories.tsx
@@ -52,7 +52,26 @@ Positions.args = {
 };
 
 export const NoData = Template.bind({});
-NoData.args = { dataSource: new EmptyDataSource(), interval: Interval.I5M };
+NoData.args = {
+  dataSource: new EmptyDataSource(),
+  interval: Interval.I5M,
+  options: {
+    notEnoughDataText: (
+      <div style={{ height: "5rem" }}>
+        <span style={{ display: "block", fontSize: "2rem", color: "salmon" }}>
+          No
+        </span>{" "}
+        <span
+          style={{ fontSize: "1rem", color: "chocolate", marginTop: "-2rem" }}
+        >
+          any
+        </span>{" "}
+        <span style={{ fontSize: "2.5rem", color: "darkorange" }}>data</span>{" "}
+        <span style={{ fontSize: "3rem", color: "indianred" }}>☹</span>
+      </div>
+    ),
+  },
+};
 
 export const SimpleMode = Template.bind({});
 SimpleMode.args = {

--- a/src/components/chart/chart.tsx
+++ b/src/components/chart/chart.tsx
@@ -51,6 +51,7 @@ export type Options = {
   simple?: boolean;
   initialNumCandlesToDisplay?: number;
   initialNumCandlesToFetch?: number;
+  notEnoughDataText?: React.ReactNode | string;
 };
 
 export type ChartProps = {
@@ -92,8 +93,9 @@ export const Chart = forwardRef(
         initialNumCandles = INITIAL_NUM_CANDLES_TO_DISPLAY,
       initialNumCandlesToFetch:
         initialNumCandlesToFetch = INITIAL_NUM_CANDLES_TO_FETCH,
+      notEnoughDataText,
     } = options;
-
+    console.log("notEnoughDataText", notEnoughDataText);
     useImperativeHandle(ref, () => ({
       panBy: (n: number) => {
         chartRef.current.panBy(n);
@@ -303,7 +305,7 @@ export const Chart = forwardRef(
     if (!scenegraph) {
       return (
         <div ref={styleRef} className="chart__wrapper" data-theme={theme}>
-          <NonIdealState title="No data found" />
+          <NonIdealState title={notEnoughDataText || "No data found"} />
         </div>
       );
     }

--- a/src/components/chart/chart.tsx
+++ b/src/components/chart/chart.tsx
@@ -95,7 +95,6 @@ export const Chart = forwardRef(
         initialNumCandlesToFetch = INITIAL_NUM_CANDLES_TO_FETCH,
       notEnoughDataText,
     } = options;
-    console.log("notEnoughDataText", notEnoughDataText);
     useImperativeHandle(ref, () => ({
       panBy: (n: number) => {
         chartRef.current.panBy(n);

--- a/src/components/depth-chart/depth-chart.tsx
+++ b/src/components/depth-chart/depth-chart.tsx
@@ -59,7 +59,7 @@ export type DepthChartProps = {
   /**
    * Override the default text to display when there is not enough data.
    */
-  notEnoughDataText?: string;
+  notEnoughDataText?: React.ReactNode | string;
 
   /**
    * Light or dark theme

--- a/src/components/non-ideal-state/non-ideal-state.tsx
+++ b/src/components/non-ideal-state/non-ideal-state.tsx
@@ -8,7 +8,7 @@ import { useDelayShow } from "../../hooks";
 export type NonIdealStateProps = {
   delay?: number;
   description?: string;
-  title: string;
+  title: React.ReactNode | string;
 };
 
 export const NonIdealState = ({


### PR DESCRIPTION
- Add parameter notEnoughDataText: ReactNode | string to the chart component. 
- Adjust accordingly depth-chart parameter
- Adjust story book case for new possibilities