### PR TITLE
feat: expose depth chart stroke width

### DIFF
--- a/src/components/chart/chart.tsx
+++ b/src/components/chart/chart.tsx
@@ -39,7 +39,7 @@ import {
 import { ErrorBoundary } from "../error-boundary";
 import { NonIdealState } from "../non-ideal-state";
 import { PlotContainer } from "../plot-container";
-import { Colors, getColors } from "./helpers";
+import { Colors, Dimensions, getColors, getDimensions } from "./helpers";
 import { useOnReady } from "./hooks";
 
 const noop = () => {};
@@ -123,6 +123,11 @@ export const Chart = forwardRef(
     const [annotations, setAnnotations] = useState<Annotation[]>([]);
     const [internalInterval, setInternalInterval] = useState(interval);
     const [colors, setColors] = useState<Colors>(getColors(null));
+
+    const [dimensions, setDimensions] = useState<Dimensions>(
+      getDimensions(null)
+    );
+
     const [loading, setLoading] = useState(true);
 
     // Callback for fetching historical data
@@ -170,10 +175,17 @@ export const Chart = forwardRef(
         parse(
           specification,
           getCandleWidth(internalInterval),
+          dimensions.strokeWidth,
           dataSource.decimalPlaces,
           annotations
         ),
-      [annotations, dataSource.decimalPlaces, internalInterval, specification]
+      [
+        annotations,
+        dataSource.decimalPlaces,
+        dimensions.strokeWidth,
+        internalInterval,
+        specification,
+      ]
     );
 
     // Initial data fetch and subscriptions
@@ -245,7 +257,10 @@ export const Chart = forwardRef(
 
     useEffect(() => {
       // Hack to ensure we pick up the changed css
-      requestAnimationFrame(() => setColors(getColors(styleRef?.current)));
+      requestAnimationFrame(() => {
+        setColors(getColors(styleRef?.current));
+        setDimensions(getDimensions(styleRef?.current));
+      });
     }, [theme]);
 
     const handleViewportChanged = useCallback(

--- a/src/components/chart/helpers/helpers-dimensions.ts
+++ b/src/components/chart/helpers/helpers-dimensions.ts
@@ -1,0 +1,38 @@
+/**
+ * Checks if `string` ends with the given target string.
+ */
+export function endsWith(string: string, target: string): boolean {
+  const length = string.length;
+
+  const position = length - target.length;
+
+  return position >= 0 && string.slice(position, length) === target;
+}
+
+function string2num(string: string, fallback = 1) {
+  let width = fallback;
+
+  if (endsWith(string, "px")) {
+    width = Number(string.slice(0, -2));
+  } else if (typeof Number.parseFloat(string) === "number") {
+    width = Number.parseFloat(string);
+  }
+
+  return width;
+}
+
+export interface Dimensions {
+  strokeWidth: number;
+}
+
+export function getDimensions(element: HTMLElement | null): Dimensions {
+  const cssStyleDeclaration = element ? getComputedStyle(element) : null;
+
+  return {
+    strokeWidth: string2num(
+      cssStyleDeclaration
+        ?.getPropertyValue("--pennant-candlestick-stroke-width")
+        .trim() || "1px"
+    ),
+  };
+}

--- a/src/components/chart/helpers/index.ts
+++ b/src/components/chart/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from "./helpers-color";
+export * from "./helpers-dimensions";

--- a/src/components/depth-chart/chart.ts
+++ b/src/components/depth-chart/chart.ts
@@ -6,7 +6,7 @@ import { orderBy, sortBy, zip } from "lodash";
 import cumsum from "../../math/array/cumsum";
 import { Contents } from "./contents";
 import { AXIS_HEIGHT, PriceLevel } from "./depth-chart";
-import { Colors } from "./helpers";
+import { Colors, Dimensions } from "./helpers";
 import { UI } from "./ui";
 
 function getMidPrice(
@@ -58,6 +58,7 @@ export class Chart extends EventEmitter {
   private volumeFormat: (volume: number) => string;
 
   private _colors: Colors;
+  private _dimensions: Dimensions;
 
   constructor(options: {
     chartView: HTMLCanvasElement;
@@ -68,12 +69,14 @@ export class Chart extends EventEmitter {
     priceFormat: (price: number) => string;
     volumeFormat: (volume: number) => string;
     colors: Colors;
+    dimensions: Dimensions;
   }) {
     super();
 
     this.priceFormat = options.priceFormat;
     this.volumeFormat = options.volumeFormat;
     this._colors = options.colors;
+    this._dimensions = options.dimensions;
 
     this.chart = new Contents({
       view: options.chartView,
@@ -81,6 +84,7 @@ export class Chart extends EventEmitter {
       width: options.width,
       height: options.height,
       colors: options.colors,
+      dimensions: options.dimensions,
     });
 
     this.axis = new UI({
@@ -244,6 +248,7 @@ export class Chart extends EventEmitter {
     }
 
     this.chart.colors = this._colors;
+    this.chart.dimensions = this._dimensions;
 
     this.chart.update(
       cumulativeBuy.map((point) => [
@@ -296,6 +301,13 @@ export class Chart extends EventEmitter {
 
   set colors(colors: Colors) {
     this._colors = colors;
+
+    this.update();
+    this.render();
+  }
+
+  set dimensions(dimensions: Dimensions) {
+    this._dimensions = dimensions;
 
     this.update();
     this.render();

--- a/src/components/depth-chart/contents.ts
+++ b/src/components/depth-chart/contents.ts
@@ -3,12 +3,14 @@ import { curveStepAfter } from "d3-shape";
 import { Renderer } from "../../renderer";
 import { Container } from "../../renderer/display";
 import { DepthCurve } from "./display-objects";
-import { Colors } from "./helpers";
+import { Colors, Dimensions } from "./helpers";
 
 type ContentsColors = Pick<
   Colors,
   "buyFill" | "buyStroke" | "sellFill" | "sellStroke"
 >;
+
+type ContentsDimensions = Pick<Dimensions, "strokeWidth">;
 
 /**
  * Responsible for drawing area curves for depth chart.
@@ -21,6 +23,7 @@ export class Contents {
   public sellCurve: DepthCurve;
 
   public colors: ContentsColors;
+  public dimensions: ContentsDimensions;
 
   constructor(options: {
     view: HTMLCanvasElement;
@@ -28,6 +31,7 @@ export class Contents {
     width: number;
     height: number;
     colors: ContentsColors;
+    dimensions: ContentsDimensions;
   }) {
     this.renderer = new Renderer({
       view: options.view,
@@ -37,16 +41,19 @@ export class Contents {
     });
 
     this.colors = options.colors;
+    this.dimensions = options.dimensions;
 
     this.buyCurve = new DepthCurve(
-      options.colors.buyStroke,
       options.colors.buyFill,
+      options.colors.buyStroke,
+      options.dimensions.strokeWidth,
       curveStepAfter
     );
 
     this.sellCurve = new DepthCurve(
-      options.colors.sellStroke,
       options.colors.sellFill,
+      options.colors.sellStroke,
+      options.dimensions.strokeWidth,
       curveStepAfter
     );
 
@@ -69,7 +76,8 @@ export class Contents {
       this.renderer.view.height,
       resolution,
       this.colors.buyFill,
-      this.colors.buyStroke
+      this.colors.buyStroke,
+      this.dimensions.strokeWidth
     );
 
     this.sellCurve.update(
@@ -77,7 +85,8 @@ export class Contents {
       this.renderer.view.height,
       resolution,
       this.colors.sellFill,
-      this.colors.sellStroke
+      this.colors.sellStroke,
+      this.dimensions.strokeWidth
     );
   }
 }

--- a/src/components/depth-chart/depth-chart.tsx
+++ b/src/components/depth-chart/depth-chart.tsx
@@ -13,7 +13,7 @@ import { ThemeVariant } from "../../types";
 import { NonIdealState } from "../non-ideal-state";
 import { Chart } from "./chart";
 import styles from "./depth-chart.module.css";
-import { getColors } from "./helpers";
+import { getColors, getDimensions } from "./helpers";
 
 function defaultVolumeFormat(volume: number) {
   return numberFormatter(0).format(volume);
@@ -110,6 +110,7 @@ export const DepthChart = forwardRef(
      */
     useEffect(() => {
       const colors = getColors(styleRef?.current);
+      const dimensions = getDimensions(styleRef?.current);
 
       chartRef.current = new Chart({
         chartView: contentsRef.current,
@@ -120,6 +121,7 @@ export const DepthChart = forwardRef(
         priceFormat,
         volumeFormat,
         colors,
+        dimensions,
       });
 
       return () => {
@@ -158,9 +160,10 @@ export const DepthChart = forwardRef(
     }, [midPrice]);
 
     useEffect(() => {
-      requestAnimationFrame(
-        () => (chartRef.current.colors = getColors(styleRef?.current))
-      );
+      requestAnimationFrame(() => {
+        chartRef.current.colors = getColors(styleRef?.current);
+        chartRef.current.dimensions = getDimensions(styleRef?.current);
+      });
     }, [theme]);
 
     useImperativeHandle(ref, () => ({

--- a/src/components/depth-chart/display-objects/depth-curve.ts
+++ b/src/components/depth-chart/display-objects/depth-curve.ts
@@ -11,23 +11,26 @@ export class DepthCurve extends Container {
   private area: Graphics = new Graphics();
   private line: Graphics = new Graphics();
 
-  private stroke: number;
   private fill: number;
+  private stroke: number;
+  private width: number;
   private curve: CurveFactory;
 
   constructor(
-    stroke: number = 0,
     fill: number = 0xffffff,
+    stroke: number = 0,
+    width: number = 1,
     curve: CurveFactory = curveStepBefore
   ) {
     super();
 
-    this.stroke = stroke;
     this.fill = fill;
+    this.stroke = stroke;
+    this.width = width;
     this.curve = curve;
 
     this.area.lineStyle({ width: 0 });
-    this.line.lineStyle({ width: 1, color: stroke, alpha: 0.5 });
+    this.line.lineStyle({ width: width, color: stroke, alpha: 0.5 });
 
     this.addChild(this.area);
     this.addChild(this.line);
@@ -38,10 +41,12 @@ export class DepthCurve extends Container {
     height: number,
     resolution: number = 1,
     fill: number = 0xffffff,
-    stroke: number = 0
+    stroke: number = 0,
+    width: number = 1
   ): void {
     this.fill = fill;
     this.stroke = stroke;
+    this.width = width;
 
     this.area.clear();
     this.area.beginFill(this.fill, 1);
@@ -49,7 +54,7 @@ export class DepthCurve extends Container {
     this.area.endFill();
 
     this.line.clear();
-    this.line.lineStyle({ width: 1, color: this.stroke });
+    this.line.lineStyle({ width: this.width, color: this.stroke });
     this.line.drawLine(points, this.curve);
   }
 }

--- a/src/components/depth-chart/helpers/helpers-dimensions.ts
+++ b/src/components/depth-chart/helpers/helpers-dimensions.ts
@@ -1,0 +1,38 @@
+/**
+ * Checks if `string` ends with the given target string.
+ */
+export function endsWith(string: string, target: string): boolean {
+  const length = string.length;
+
+  const position = length - target.length;
+
+  return position >= 0 && string.slice(position, length) === target;
+}
+
+function string2num(string: string, fallback = 1) {
+  let width = fallback;
+
+  if (endsWith(string, "px")) {
+    width = Number(string.slice(0, -2));
+  } else if (typeof Number.parseFloat(string) === "number") {
+    width = Number.parseFloat(string);
+  }
+
+  return width;
+}
+
+export interface Dimensions {
+  strokeWidth: number;
+}
+
+export function getDimensions(element: HTMLElement | null): Dimensions {
+  const cssStyleDeclaration = element ? getComputedStyle(element) : null;
+
+  return {
+    strokeWidth: string2num(
+      cssStyleDeclaration
+        ?.getPropertyValue("--pennant-depth-stroke-width")
+        .trim() || "1px"
+    ),
+  };
+}

--- a/src/components/depth-chart/helpers/index.ts
+++ b/src/components/depth-chart/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from "./helpers-color";
+export * from "./helpers-dimensions";

--- a/src/components/plot-container/plot-container.stories.tsx
+++ b/src/components/plot-container/plot-container.stories.tsx
@@ -84,6 +84,6 @@ export const Simple = Template.bind({});
 Simple.args = {
   interval: Interval.I5M,
   overlays: [],
-  scenegraph: parse(specification, 100, 0, []) as Scenegraph,
+  scenegraph: parse(specification, 100, 1, 0, []) as Scenegraph,
   simple: false,
 };

--- a/src/elements/element-bar.ts
+++ b/src/elements/element-bar.ts
@@ -8,6 +8,7 @@ export type Bar = {
   height: number;
   fill: string;
   stroke: string;
+  lineWidth: number;
 };
 
 export class BarElement implements PositionalElement {
@@ -17,9 +18,10 @@ export class BarElement implements PositionalElement {
   readonly height: number;
   readonly fill: string;
   readonly stroke: string;
+  readonly lineWidth: number;
 
   constructor(cfg: any) {
-    const { x, y, width, height, fill, stroke } = cfg;
+    const { x, y, width, height, fill, stroke, lineWidth } = cfg;
 
     this.x = x;
     this.y = y;
@@ -27,6 +29,7 @@ export class BarElement implements PositionalElement {
     this.height = height;
     this.fill = fill;
     this.stroke = stroke;
+    this.lineWidth = lineWidth;
   }
 
   draw(
@@ -50,7 +53,7 @@ export class BarElement implements PositionalElement {
     ctx.fill();
 
     if (this.stroke) {
-      ctx.lineWidth = 1 / pixelRatio;
+      ctx.lineWidth = this.lineWidth / pixelRatio;
       ctx.strokeStyle = this.stroke;
       ctx.stroke();
     }

--- a/src/helpers/helpers-scenegraph.ts
+++ b/src/helpers/helpers-scenegraph.ts
@@ -62,7 +62,8 @@ export function getBarConfig(
   y2: string,
   width: number,
   fill: string | null,
-  stroke: string | null
+  stroke: string | null,
+  lineWidth: number | null
 ) {
   let base = 0;
 
@@ -77,6 +78,7 @@ export function getBarConfig(
     width: width * (1 - PADDING_INNER),
     fill: fill,
     stroke: stroke,
+    lineWidth: lineWidth ?? 1,
   };
 }
 

--- a/src/scenegraph/parse.test.ts
+++ b/src/scenegraph/parse.test.ts
@@ -18,7 +18,7 @@ test("simple case", () => {
     ],
   };
 
-  const scenegraph = parse(input, 10, 0, []);
+  const scenegraph = parse(input, 10, 1, 0, []);
 
   expect(scenegraph).toHaveProperty("panes");
   expect(scenegraph?.panes).toHaveLength(1);
@@ -111,7 +111,7 @@ test("candlestick chart with study", () => {
     ],
   };
 
-  const scenegraph = parse(input, 10, 0, []);
+  const scenegraph = parse(input, 10, 1, 0, []);
 
   expect(scenegraph).toHaveProperty("panes");
   expect(scenegraph?.panes).toHaveLength(2);
@@ -197,7 +197,7 @@ test("recursively parse a layer", () => {
     ],
   };
 
-  const layer = parseLayer(input, { values: [] }, {}, 10);
+  const layer = parseLayer(input, { values: [] }, {}, 10, 1);
 
   expect(layer).toHaveLength(4);
 });

--- a/src/scenegraph/parse.ts
+++ b/src/scenegraph/parse.ts
@@ -46,7 +46,8 @@ export function compileLayer(
   data: Data,
   encoding: Encoding<Field>,
   mark: Mark | MarkDef,
-  candleWidth: number
+  candleWidth: number,
+  lineWidth: number
 ) {
   let markType: string;
   let cfg = {};
@@ -91,7 +92,8 @@ export function compileLayer(
           encoding.y2?.field!,
           candleWidth,
           getConditionalColor(encoding.fill)(d),
-          getConditionalColor(encoding.stroke)(d)
+          getConditionalColor(encoding.stroke)(d),
+          lineWidth
         );
       } else if (markType === "rule") {
         cfg = getRuleConfig(
@@ -122,7 +124,8 @@ export function parseLayer(
   layer: BaseSpec,
   data: Data,
   encoding: Encoding<Field>,
-  candleWidth: number
+  candleWidth: number,
+  lineWidth: number
 ) {
   const series: any[] = [];
   let layerData = data;
@@ -138,14 +141,20 @@ export function parseLayer(
 
   if (layer?.mark) {
     series.push(
-      compileLayer(layerData, layerEncoding, layer.mark, candleWidth)
+      compileLayer(layerData, layerEncoding, layer.mark, candleWidth, lineWidth)
     );
   }
 
   if (layer?.layer) {
     for (const subLayer of layer.layer) {
       series.push(
-        ...parseLayer(subLayer, layerData, layerEncoding, candleWidth)
+        ...parseLayer(
+          subLayer,
+          layerData,
+          layerEncoding,
+          candleWidth,
+          lineWidth
+        )
       );
     }
   }
@@ -199,6 +208,7 @@ function extractYEncodingFields(layer: BaseSpec) {
 export function parse(
   specification: TopLevelSpec,
   candleWidth: number,
+  lineWidth: number,
   decimalPlaces: number,
   annotations: Annotation[]
 ): Scenegraph | null {
@@ -337,7 +347,8 @@ export function parse(
               pane,
               { values: newData },
               specification.encoding ?? {},
-              candleWidth
+              candleWidth,
+              lineWidth
             ),
             bounds: calculateScales(
               pane,

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -162,6 +162,9 @@
   /* Transitions. */
   --pennant-transition-fast: 100ms;
   --pennant-transition-slow: 300ms;
+
+  /* Dimensions. */
+  --pennant-depth-stroke-width: 2px;
 }
 
 [data-theme="dark"] {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -164,6 +164,7 @@
   --pennant-transition-slow: 300ms;
 
   /* Dimensions. */
+  --pennant-candlestick-stroke-width: 1px;
   --pennant-depth-stroke-width: 2px;
 }
 


### PR DESCRIPTION
Introduces two new CSS Variables:

- `--pennant-candlestick-stroke-width: 1px`
- `--pennant-depth-stroke-width: 2px`