### PR TITLE
feat(candlestick-chart): add option to set default study height

### DIFF
--- a/src/components/chart/chart.stories.tsx
+++ b/src/components/chart/chart.stories.tsx
@@ -27,6 +27,16 @@ Default.args = {
   interval: Interval.I5M,
 };
 
+export const Volume = Template.bind({});
+Volume.args = {
+  ...Default.args,
+  options: {
+    chartType: "candle",
+    studies: ["volume"],
+    studySize: "33.333%",
+  },
+};
+
 export const Study = Template.bind({});
 Study.args = {
   ...Default.args,

--- a/src/components/chart/chart.tsx
+++ b/src/components/chart/chart.tsx
@@ -52,6 +52,17 @@ export type Options = {
   initialNumCandlesToDisplay?: number;
   initialNumCandlesToFetch?: number;
   notEnoughDataText?: React.ReactNode | string;
+  /**
+   * Preferred size of a study pane. The Chart will attempt to use this size when adding a study pane (including on initial mount) as well as when a user double clicks a sash, or the `reset` method is called on the Chart instance.
+   * @remarks The size can either be a number or a string.
+   *
+   * If it is a number it will be interpreted as a number of pixels.
+   *
+   * If it is a string it should end in either "px" or "%". If it ends in "px" it will be interpreted as a number of pixels, e.g. "120px".
+   *
+   * If it ends in "%" it will be interpreted as a percentage of the size of the main pane, e.g. "50%".
+   */
+  studySize?: number | string;
 };
 
 export type ChartProps = {
@@ -76,6 +87,7 @@ export const Chart = forwardRef(
         overlays: [],
         initialNumCandlesToDisplay: INITIAL_NUM_CANDLES_TO_DISPLAY,
         initialNumCandlesToFetch: INITIAL_NUM_CANDLES_TO_FETCH,
+        studySize: "50%",
       },
       initialViewport,
       theme = "dark",
@@ -94,6 +106,7 @@ export const Chart = forwardRef(
       initialNumCandlesToFetch:
         initialNumCandlesToFetch = INITIAL_NUM_CANDLES_TO_FETCH,
       notEnoughDataText,
+      studySize = "50%",
     } = options;
     useImperativeHandle(ref, () => ({
       panBy: (n: number) => {
@@ -339,6 +352,7 @@ export const Chart = forwardRef(
             simple={simple}
             initialNumCandles={initialNumCandles}
             colors={colors}
+            studySize={studySize}
             onViewportChanged={handleViewportChanged}
             onGetDataRange={handleGetDataRange}
             onClosePane={handleClosePane}

--- a/src/components/plot-container/plot-container.tsx
+++ b/src/components/plot-container/plot-container.tsx
@@ -24,17 +24,10 @@ import {
   Viewport,
 } from "../../types";
 import { FcElement, Interval } from "../../types";
+import { calculatePreferredSize } from "../../util/misc";
 import { Colors } from "../chart/helpers";
 import { PaneView } from "../pane-view";
 import { XAxisView } from "../x-axis-view";
-
-function calculatePreferredSize(n: number, main: boolean) {
-  if (main) {
-    return `${100 * (2 / (1 + n))}%`;
-  } else {
-    return `${100 * ((1 - 2 / (1 + n)) / Math.max(n - 1, 1))}%`;
-  }
-}
 
 export type PlotContainerProps = {
   width: number;
@@ -47,6 +40,7 @@ export type PlotContainerProps = {
   simple: boolean;
   initialNumCandles: number;
   colors: Colors;
+  studySize: number | string;
   onViewportChanged?: (viewport: Viewport) => void;
   onRightClick?: (event: any) => void;
   onGetDataRange?: (from: Date, to: Date, interval: Interval) => void;
@@ -68,6 +62,7 @@ export const PlotContainer = forwardRef<
       simple,
       initialNumCandles,
       colors,
+      studySize,
       onViewportChanged = () => {},
       onRightClick = () => {},
       onGetDataRange = () => {},
@@ -251,7 +246,7 @@ export const PlotContainer = forwardRef<
 
     useEffect(() => {
       allotmentRef.current.reset();
-    }, [numPanes]);
+    }, [numPanes, studySize]);
 
     return (
       <d3fc-group ref={chartRef} class="plot-container__chart">
@@ -268,7 +263,11 @@ export const PlotContainer = forwardRef<
           {scenegraph.panes.map((pane, index) => (
             <Allotment.Pane
               key={pane.id}
-              preferredSize={calculatePreferredSize(numPanes, index === 0)}
+              preferredSize={calculatePreferredSize(
+                studySize,
+                numPanes,
+                index === 0
+              )}
             >
               <PaneView
                 ref={refs[pane.id]}

--- a/src/util/misc/calculate-preferred-size.test.ts
+++ b/src/util/misc/calculate-preferred-size.test.ts
@@ -1,0 +1,57 @@
+import { calculatePreferredSize } from "./calculate-preferred-size";
+
+describe("calculatePreferredSize", () => {
+  test("percentage units", () => {
+    expect(
+      Number((calculatePreferredSize("100%", 2, true) as string).slice(0, -1))
+    ).toBeCloseTo(50);
+    expect(
+      Number((calculatePreferredSize("100%", 2, false) as string).slice(0, -1))
+    ).toBeCloseTo(50);
+
+    expect(
+      Number((calculatePreferredSize("100%", 3, true) as string).slice(0, -1))
+    ).toBeCloseTo(33.3333);
+    expect(
+      Number((calculatePreferredSize("100%", 3, false) as string).slice(0, -1))
+    ).toBeCloseTo(33.3333);
+
+    expect(
+      Number((calculatePreferredSize("100%", 4, true) as string).slice(0, -1))
+    ).toBeCloseTo(25);
+    expect(
+      Number((calculatePreferredSize("100%", 4, false) as string).slice(0, -1))
+    ).toBeCloseTo(25);
+
+    expect(
+      Number((calculatePreferredSize("50%", 2, true) as string).slice(0, -1))
+    ).toBeCloseTo(66.6666);
+    expect(
+      Number((calculatePreferredSize("50%", 2, false) as string).slice(0, -1))
+    ).toBeCloseTo(33.3333);
+
+    expect(
+      Number((calculatePreferredSize("50%", 3, true) as string).slice(0, -1))
+    ).toBeCloseTo(50);
+    expect(
+      Number((calculatePreferredSize("50%", 3, false) as string).slice(0, -1))
+    ).toBeCloseTo(25);
+
+    expect(
+      Number((calculatePreferredSize("50%", 4, true) as string).slice(0, -1))
+    ).toBeCloseTo(40);
+    expect(
+      Number((calculatePreferredSize("50%", 4, false) as string).slice(0, -1))
+    ).toBeCloseTo(20);
+  });
+
+  test("pixel units", () => {
+    expect(calculatePreferredSize("100px", 2, true)).toBeUndefined();
+    expect(calculatePreferredSize("100px", 2, false)).toEqual(100);
+  });
+
+  test("number", () => {
+    expect(calculatePreferredSize(120, 2, true)).toBeUndefined();
+    expect(calculatePreferredSize(120, 2, false)).toEqual(120);
+  });
+});

--- a/src/util/misc/calculate-preferred-size.ts
+++ b/src/util/misc/calculate-preferred-size.ts
@@ -1,0 +1,47 @@
+export function calculatePreferredSize(
+  studySize: number | string,
+  n: number,
+  main: boolean
+) {
+  if (typeof studySize === "string") {
+    const preferredSize = studySize.trim();
+
+    if (preferredSize.endsWith("%")) {
+      const proportion = Number(preferredSize.slice(0, -1)) / 100;
+
+      const ratio = 1 / proportion;
+
+      const mainSize = ratio / (ratio + (n - 1));
+
+      if (main) {
+        return `${100 * mainSize}%`;
+      } else {
+        return `${100 * ((1 - mainSize) / Math.max(n - 1, 1))}%`;
+      }
+    } else if (preferredSize.endsWith("px")) {
+      const pixels = Number(preferredSize.slice(0, -2));
+
+      if (main) {
+        return undefined;
+      } else {
+        return pixels;
+      }
+    } else if (typeof Number.parseFloat(preferredSize) === "number") {
+      const pixels = Number.parseFloat(preferredSize);
+
+      if (main) {
+        return undefined;
+      } else {
+        return pixels;
+      }
+    }
+  } else {
+    const pixels = studySize;
+
+    if (main) {
+      return undefined;
+    } else {
+      return pixels;
+    }
+  }
+}

--- a/src/util/misc/index.ts
+++ b/src/util/misc/index.ts
@@ -1,0 +1,1 @@
+export * from "./calculate-preferred-size";


### PR DESCRIPTION
Adds support for customizing the height of studies. If you provide a number of string with `px` units it will make a best effort to respect that. If you provide a string with `%` units then it will use that to derive the study height based on the main pane's height. For example, if you use `"100%"` then the main pane will be the same size as any studies. The previous default was effectively `"50%`, i.e. studies appeared with half the height of the main pane.

https://user-images.githubusercontent.com/981531/217880760-08b667fc-a763-4c6c-a47d-98fbb83df388.mov

I just noticed that I didn't clean up the code in the `calculatePreferredSize` function. Let me fix that.
