### PR TITLE
fix(candlestick-chart): improve alignment of canvas elements

### DIFF
--- a/src/ui/elements/element-bar.ts
+++ b/src/ui/elements/element-bar.ts
@@ -1,4 +1,3 @@
-import { align, alignSpan } from "@util/misc";
 import { PositionalElement, ScaleLinear, ScaleTime } from "@util/types";
 
 export type Bar = {
@@ -43,10 +42,10 @@ export class BarElement implements PositionalElement {
     const pixelWidth = Math.max(xScale(this.width) - xScale(0), 1 / pixelRatio);
 
     ctx.rect(
-      align(xScale(this.x.getTime() - this.width / 2), pixelRatio),
-      align(yScale(this.y), pixelRatio),
-      alignSpan(pixelWidth, pixelRatio),
-      alignSpan(Math.abs(yScale(this.height) - yScale(0)), pixelRatio)
+      xScale(this.x.getTime() - this.width / 2),
+      yScale(this.y),
+      pixelWidth,
+      Math.abs(yScale(this.height) - yScale(0))
     );
 
     ctx.fillStyle = this.fill;

--- a/src/ui/elements/element-grid.ts
+++ b/src/ui/elements/element-grid.ts
@@ -1,4 +1,4 @@
-import { align, getNumXTicks, getNumYTicks } from "@util/misc";
+import { getNumXTicks, getNumYTicks } from "@util/misc";
 import { RenderableElement, ScaleLinear, ScaleTime } from "@util/types";
 
 function addGridPath(
@@ -25,8 +25,8 @@ function addGridPath(
     ctx.fillStyle = "transparent";
     ctx.lineWidth = 1 / pixelRatio;
 
-    ctx.moveTo(align(xScale(tick)!, pixelRatio), yRange[0]);
-    ctx.lineTo(align(xScale(tick)!, pixelRatio), yRange[1]);
+    ctx.moveTo(xScale(tick)!, yRange[0]);
+    ctx.lineTo(xScale(tick)!, yRange[1]);
 
     ctx.fill();
     ctx.stroke();
@@ -43,8 +43,8 @@ function addGridPath(
     ctx.fillStyle = "transparent";
     ctx.lineWidth = 1 / pixelRatio;
 
-    ctx.moveTo(xRange[0], align(yScale(tick)!, pixelRatio));
-    ctx.lineTo(xRange[1], align(yScale(tick)!, pixelRatio));
+    ctx.moveTo(xRange[0], yScale(tick)!);
+    ctx.lineTo(xRange[1], yScale(tick)!);
 
     ctx.fill();
     ctx.stroke();

--- a/src/ui/elements/element-line.ts
+++ b/src/ui/elements/element-line.ts
@@ -1,4 +1,3 @@
-import { align, alignSpan } from "@util/misc";
 import { PositionalElement, ScaleLinear, ScaleTime } from "@util/types";
 import { curveLinear, line as d3Line } from "d3-shape";
 
@@ -31,9 +30,7 @@ export class LineElement implements PositionalElement {
     yScale: ScaleLinear,
     pixelRatio: number = 1
   ) {
-    this.lineGenerator
-      .x((d) => align(xScale(d[0]), pixelRatio))
-      .y((d) => alignSpan(yScale(d[1]), pixelRatio));
+    this.lineGenerator.x((d) => xScale(d[0])).y((d) => yScale(d[1]));
 
     this.lineGenerator.context(ctx);
 

--- a/src/ui/elements/element-rule.ts
+++ b/src/ui/elements/element-rule.ts
@@ -1,4 +1,3 @@
-import { align } from "@util/misc";
 import { PositionalElement, ScaleLinear, ScaleTime } from "@util/types";
 
 export type Rule = {
@@ -53,8 +52,8 @@ export class RuleElement implements PositionalElement {
 
     ctx.beginPath();
 
-    ctx.moveTo(align(x, pixelRatio), align(y, pixelRatio));
-    ctx.lineTo(align(x2, pixelRatio), align(y2, pixelRatio));
+    ctx.moveTo(x, y);
+    ctx.lineTo(x2, y2);
 
     ctx.strokeStyle = this.color;
     ctx.lineCap = "butt";

--- a/src/ui/elements/element-tick.ts
+++ b/src/ui/elements/element-tick.ts
@@ -1,4 +1,3 @@
-import { align } from "@util/misc";
 import { PositionalElement, ScaleLinear, ScaleTime } from "@util/types";
 
 export class TickElement implements PositionalElement {
@@ -27,23 +26,15 @@ export class TickElement implements PositionalElement {
     ctx.beginPath();
 
     ctx.moveTo(
-      align(
-        xScale(
-          this.x.getTime() - (this.orient === "left" ? this.width / 2 : 0)
-        ),
-        pixelRatio
-      ),
-      align(yScale(this.y), pixelRatio)
+      xScale(this.x.getTime() - (this.orient === "left" ? this.width / 2 : 0)),
+
+      yScale(this.y)
     );
 
     ctx.lineTo(
-      align(
-        xScale(
-          this.x.getTime() + (this.orient === "right" ? this.width / 2 : 0)
-        ),
-        pixelRatio
-      ),
-      align(yScale(this.y), pixelRatio)
+      xScale(this.x.getTime() + (this.orient === "right" ? this.width / 2 : 0)),
+
+      yScale(this.y)
     );
 
     ctx.strokeStyle = this.color;

--- a/src/ui/elements/element-y-axis-annotation.ts
+++ b/src/ui/elements/element-y-axis-annotation.ts
@@ -1,5 +1,5 @@
 import { TICK_LABEL_FONT_SIZE, Y_AXIS_WIDTH } from "@util/constants";
-import { align, formatter } from "@util/misc";
+import { formatter } from "@util/misc";
 import { RenderableElement, ScaleLinear, ScaleTime } from "@util/types";
 
 import { Colors } from "../../feature/candlestick-chart/helpers";
@@ -31,8 +31,8 @@ function addYAxisPath(
     ctx.strokeStyle = colors.textSecondary;
 
     ctx.beginPath();
-    ctx.moveTo(xScale.range()[0], align(y) + 0.5);
-    ctx.lineTo(xScale.range()[1], align(y) + 0.5);
+    ctx.moveTo(xScale.range()[0], y + 0.5);
+    ctx.lineTo(xScale.range()[1], y + 0.5);
     ctx.stroke();
     ctx.closePath();
 

--- a/src/ui/elements/element-y-axis.ts
+++ b/src/ui/elements/element-y-axis.ts
@@ -1,6 +1,6 @@
 import { hex2rgb, string2hex } from "@ui/renderer";
 import { TICK_LABEL_FONT_SIZE, Y_AXIS_WIDTH } from "@util/constants";
-import { align, getNumYTicks } from "@util/misc";
+import { getNumYTicks } from "@util/misc";
 import { RenderableElement, ScaleLinear, ScaleTime } from "@util/types";
 
 import { Colors } from "../../feature/candlestick-chart/helpers";
@@ -78,8 +78,8 @@ function addYAxisPath(
 
   ctx.beginPath();
   ctx.strokeStyle = colors.emphasis300;
-  ctx.moveTo(align(xRange[1] - Y_AXIS_WIDTH, pixelRatio), yRange[0]);
-  ctx.lineTo(align(xRange[1] - Y_AXIS_WIDTH, pixelRatio), yRange[1]);
+  ctx.moveTo(xRange[1] - Y_AXIS_WIDTH, yRange[0]);
+  ctx.lineTo(xRange[1] - Y_AXIS_WIDTH, yRange[1]);
   ctx.stroke();
   ctx.closePath();
 }

--- a/src/util/misc/canvas.ts
+++ b/src/util/misc/canvas.ts
@@ -26,17 +26,3 @@ export function clearCanvas(
 
   ctx.restore();
 }
-
-/**
- * Returns the aligned pixel value to avoid anti-aliasing blur
- * @param x - A pixel value
- * @param pixelRatio - Device pixel ratio
- * @returns The aligned pixel value
- */
-export function align(x: number, pixelRatio: number = 1): number {
-  return Math.round(pixelRatio * Math.round(x)) / pixelRatio + 0.5 / pixelRatio;
-}
-
-export function alignSpan(x: number, pixelRatio: number = 1) {
-  return Math.round(pixelRatio * Math.round(x)) / pixelRatio;
-}


### PR DESCRIPTION
Remove functionality that attempted to line up shapes with device pixels. It's a trade-off, we now get slightly blurrier canvas elements, e.g. candles, but they are now more accurately positioned.

<img width="207" alt="Screenshot 2023-02-21 at 11 52 30" src="https://user-images.githubusercontent.com/981531/220338613-5a808ec2-dcbe-4c6d-a5ab-956840cdf4ab.png">
